### PR TITLE
feat: add run link

### DIFF
--- a/qase-core-reporter/src/reporter.ts
+++ b/qase-core-reporter/src/reporter.ts
@@ -543,6 +543,7 @@ export class QaseCoreReporter {
         } catch (err) {
             QaseCoreReporter.logger(`Error on completing run ${err as string}`);
         }
+        QaseCoreReporter.logger(chalk`{blue https://app.qase.io/run/${this.options.projectCode}/dashboard/${this.runId}}`);
     }
 
     public addTestResult(test: TestResult, status: ResultCreateStatusEnum, attachment?: any[]): void {


### PR DESCRIPTION
Added additional log at the run completion so it'd be possible to open results right from the console output (especially useful for CI/CD runs).

Feature request: https://qase.canny.io/feature-requests/p/log-a-link-to-qase-test-run-in-playwright-test-runs]

![image](https://user-images.githubusercontent.com/51059105/188879193-bc3d50e5-531c-4add-918a-58c15fc51fae.png)
